### PR TITLE
Bump to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## 0.3.1 - 2023-03-17
+
+Adding those commits to the package:
+
+- Bump typescript from 4.9.5 to 5.0.2
+  [#100](https://github.com/fewlinesco/javascript-styleguide/pull/100)
+- Bump @remix-run/eslint-config from 1.14.0 to 1.14.3
+  [#94](https://github.com/fewlinesco/javascript-styleguide/pull/94)
+  [#98](https://github.com/fewlinesco/javascript-styleguide/pull/98)
+  [#99]((https://github.com/fewlinesco/javascript-styleguide/pull/99)
+- Bump @typescript-eslint/eslint-plugin from 5.54.0 to 5.55.0
+  [#92](https://github.com/fewlinesco/javascript-styleguide/pull/92)
+  [#97](https://github.com/fewlinesco/javascript-styleguide/pull/97)
+- Bump @typescript-eslint/parser from 5.54.0 to 5.55.0
+  [#93](https://github.com/fewlinesco/javascript-styleguide/pull/93)
+  [#96](https://github.com/fewlinesco/javascript-styleguide/pull/96)
+- Bump eslint from 8.35.0 to 8.36.0
+  [#95](https://github.com/fewlinesco/javascript-styleguide/pull/95)
+
 ## 0.3.0 - 2023-03-01
 
 Adding those commits to the package:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "name": "@fewlines/javascript-styleguide",
   "repository": "git@github.com:fewlinesco/javascript-styleguide.git",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "eslintConfig": {
     "extends": "./node",
     "env": {


### PR DESCRIPTION
Adding those commits to the package:

- Bump typescript from 4.9.5 to 5.0.2
  [#100](https://github.com/fewlinesco/javascript-styleguide/pull/100)
- Bump @remix-run/eslint-config from 1.14.0 to 1.14.3
  [#94](https://github.com/fewlinesco/javascript-styleguide/pull/94)
  [#98](https://github.com/fewlinesco/javascript-styleguide/pull/98)
  [#99]((https://github.com/fewlinesco/javascript-styleguide/pull/99)
- Bump @typescript-eslint/eslint-plugin from 5.54.0 to 5.55.0
  [#92](https://github.com/fewlinesco/javascript-styleguide/pull/92)
  [#97](https://github.com/fewlinesco/javascript-styleguide/pull/97)
- Bump @typescript-eslint/parser from 5.54.0 to 5.55.0
  [#93](https://github.com/fewlinesco/javascript-styleguide/pull/93)
  [#96](https://github.com/fewlinesco/javascript-styleguide/pull/96)
- Bump eslint from 8.35.0 to 8.36.0
  [#95](https://github.com/fewlinesco/javascript-styleguide/pull/95)